### PR TITLE
Bumps Ruby version to 3.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,10 @@
+require: 
+  - rubocop-rspec
+  - rubocop-rake
+
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 3.0
+  NewCops: enable
 
 # False positive...
 Bundler/DuplicatedGem:
@@ -23,21 +28,21 @@ Layout/ExtraSpacing:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
-Lint/EndAlignment:
+Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 
-Layout/IndentHash:
+Layout/FirstHashElementIndentation:
   Exclude:
     - Rakefile
+
+Layout/LineLength:
+  Max: 99
 
 Metrics/AbcSize:
   Max: 30
 
 Metrics/CyclomaticComplexity:
   Max: 12
-
-Metrics/LineLength:
-  Max: 99
 
 Metrics/MethodLength:
   Max: 35
@@ -91,8 +96,8 @@ Style/NegatedIf:
 Style/RedundantFreeze:
   Enabled: false
 
-Style/TrailingCommaInArguments:
+Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ language: ruby
 
 jobs:
   include:
-    - env: &adoc-latest ASCIIDOCTOR_VERSION=2.0.10
-      rvm: &ruby-latest 2.7
+    - env: &adoc-latest ASCIIDOCTOR_VERSION=2.0.12
+      rvm: &ruby-latest 3.0
+    - env: *adoc-latest
+      rvm: 2.7
     - env: *adoc-latest
       rvm: 2.6
     - env: *adoc-latest

--- a/Gemfile
+++ b/Gemfile
@@ -10,10 +10,7 @@ unless ENV.fetch('ASCIIDOCTOR_VERSION', '').empty?
 end
 
 group :development do
-  # Keep in sync with version used in opal-node-runtime <- asciidoctor.js.
-  # TODO: Maybe replace with JS version after
-  #   https://github.com/Mogztter/opal-node-compiler/issues/6 is resolved.
-  gem 'opal', github: 'opal/opal', ref: '31d26d69'
+  gem 'opal', '~> 0.10.6'
 end
 
 group :ci do

--- a/Rakefile
+++ b/Rakefile
@@ -5,8 +5,8 @@ begin
 
   RSpec::Core::RakeTask.new(:spec)
 
+  desc 'Run specification tests'
   task :test => :spec
-  task :default => :spec
 rescue LoadError => e
   warn "#{e.path} is not available"
 end
@@ -18,11 +18,16 @@ begin
     t.options = ['--display-cop-names', '--fail-level', 'W']
   end
 
-  task :default => :rubocop
+  desc 'Run specification tests and linting'
+  task :default do
+    Rake::Task[:spec].execute
+    Rake::Task[:rubocop].execute
+  end
 rescue LoadError => e
   warn "#{e.path} is not available"
 end
 
+desc 'Convert README.adoc to markdown'
 task :readme2md do
   require 'asciidoctor'
   require 'pandoc-ruby'

--- a/asciidoctor-katex.gemspec
+++ b/asciidoctor-katex.gemspec
@@ -1,4 +1,4 @@
-require File.expand_path('../lib/asciidoctor/katex/version', __FILE__)
+require File.expand_path('lib/asciidoctor/katex/version', __dir__)
 
 Gem::Specification.new do |s|
   s.name        = 'asciidoctor-katex'
@@ -12,17 +12,19 @@ Gem::Specification.new do |s|
 
   s.files       = Dir['lib/**/*', '*.gemspec', 'LICENSE*', 'README.adoc']
 
-  s.required_ruby_version = '>= 2.3'
+  s.required_ruby_version = '>= 3.0'
 
   s.add_runtime_dependency 'asciidoctor', '>= 1.5.6', '< 3.0'
-  s.add_runtime_dependency 'katex', '~> 0.4.3'
+  s.add_runtime_dependency 'katex', '~> 0.6'
 
-  s.add_development_dependency 'kramdown', '~> 1.17'
+  s.add_development_dependency 'kramdown', '~> 2.3.0'
   s.add_development_dependency 'pandoc-ruby', '~> 2.0'
-  s.add_development_dependency 'rake', '~> 12.0'
+  s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3.7'
   s.add_development_dependency 'rspec-html-matchers', '~> 0.9.1'
-  s.add_development_dependency 'rubocop', '~> 0.51.0'
+  s.add_development_dependency 'rubocop', '~> 1.8.1'
+  s.add_development_dependency 'rubocop-rake', '~> 0.5.1'
+  s.add_development_dependency 'rubocop-rspec', '~> 2.1.0'
   s.add_development_dependency 'simplecov', '~> 0.16'
   s.add_development_dependency 'yard', '~> 0.9'
 end

--- a/lib/asciidoctor/katex/opal_katex_adapter.rb
+++ b/lib/asciidoctor/katex/opal_katex_adapter.rb
@@ -28,11 +28,13 @@ module Asciidoctor::Katex
 
       begin
         `#{@katex_object}.renderToString(#{math}, #{opts}.$$smap)`
-      rescue ::JS::Error => err
-        # "#{err}" is really needed for Opal/JS, #to_s returns a different string.
-        # rubocop:disable UnneededInterpolation
-        raise ParseError.new(err, math) if "#{err}".start_with?('ParseError:')
-        raise KatexError.new(err, math)
+      rescue ::JS::Error => e
+        # rubocop:disable Style/RedundantInterpolation
+        # "#{e}" is really needed for Opal/JS, #to_s returns a different string.
+        raise ParseError.new(e, math) if "#{e}".start_with?('ParseError:')
+
+        raise KatexError.new(e, math)
+        # rubocop:enable Style/RedundantInterpolation
       end
     end
 

--- a/lib/asciidoctor/katex/ruby_katex_adapter.rb
+++ b/lib/asciidoctor/katex/ruby_katex_adapter.rb
@@ -28,10 +28,11 @@ module Asciidoctor::Katex
       opts[:error_color] = opts[:errorColor] || '#cc0000'
 
       begin
-        ::Katex.render(math, opts)
-      rescue ::ExecJS::ProgramError => err
-        raise ParseError.new(err, math) if err.to_s.start_with?('ParseError:')
-        raise KatexError.new(err, math)
+        ::Katex.render(math, **opts)
+      rescue ::ExecJS::ProgramError => e
+        raise ParseError.new(e, math) if e.to_s.start_with?('ParseError:')
+
+        raise KatexError.new(e, math)
       end
     end
 

--- a/lib/asciidoctor/katex/treeprocessor.rb
+++ b/lib/asciidoctor/katex/treeprocessor.rb
@@ -22,7 +22,10 @@ module Asciidoctor::Katex
     #   Defaults to {KatexAdapter} initialized with the *katex_options*.
     # @param require_stem_attr [Boolean] `true` to skip when `stem` attribute
     #   is not declared, `false` to process anyway.
-    def initialize(katex_options: {}, katex_renderer: nil, require_stem_attr: true, **)
+    def initialize(kwargs = {})
+      katex_options = kwargs.fetch(:katex_options, {})
+      katex_renderer = kwargs.fetch(:katex_renderer, nil)
+      require_stem_attr = kwargs.fetch(:require_stem_attr, true)
       @katex_renderer = katex_renderer || KatexAdapter.new(katex_options)
       @require_stem_attr = require_stem_attr
       super

--- a/lib/asciidoctor/katex/version.rb
+++ b/lib/asciidoctor/katex/version.rb
@@ -3,6 +3,6 @@
 module Asciidoctor
   module Katex
     # Version of the asciidoctor-katex gem.
-    VERSION = '0.3.2'
+    VERSION = '0.3.3'
   end
 end

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -24,9 +24,6 @@ Layout/SpaceBeforeComment:
 Layout/SpaceInsideBlockBraces:
   Enabled: false
 
-Layout/SpaceInsideBrackets:
-  Enabled: false
-
 Layout/SpaceInsideParens:
   Enabled: false
 
@@ -56,4 +53,10 @@ Style/SymbolArray:
   Enabled: false
 
 Style/WordArray:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleExpectations:
   Enabled: false

--- a/spec/asciidoctor/katex/treeprocessor_spec.rb
+++ b/spec/asciidoctor/katex/treeprocessor_spec.rb
@@ -1,15 +1,15 @@
-require_relative 'spec_helper'
+require_relative '../../spec_helper'
 
 require 'asciidoctor/katex/treeprocessor'
 require 'asciidoctor'
 
 
-describe 'Integration Tests' do
+describe Asciidoctor::Katex::Treeprocessor do
 
   subject(:output) { convert(input, options) }
 
   let(:input) { '' }  # this is modified in #given
-  let(:processor) { Asciidoctor::Katex::Treeprocessor.new(**processor_opts) }
+  let(:processor) { described_class.new(**processor_opts) }
   let(:processor_opts) { {} }
 
   let(:options) {
@@ -24,7 +24,7 @@ describe 'Integration Tests' do
   let(:attributes) { {} }
 
 
-  shared_examples :unprocessed do |stem_type|
+  shared_examples 'unprocessed' do |stem_type|
     it "renders #{stem_type} block unprocessed" do
       given <<~ADOC
         [#{stem_type}]
@@ -32,18 +32,18 @@ describe 'Integration Tests' do
         C = \\alpha + \\beta Y^{\\gamma} + \\epsilon
         ++++
       ADOC
-      should have_tag 'div.stemblock', text: /C = \\alpha/
-      should_not have_tag 'math'
+      expect(output).to have_tag 'div.stemblock', text: /C = \\alpha/
+      expect(output).not_to have_tag 'math'
     end
 
     it "renders inline #{stem_type}:[] unprocessed" do
       given "Do some math: #{stem_type}:[E = mc^2]"
 
-      should have_tag 'p', text: /Do some math:.*E = mc\^2/
+      expect(output).to have_tag 'p', text: /Do some math:.*E = mc\^2/
     end
   end
 
-  shared_examples :processed do |stem_type|
+  shared_examples 'processed' do |stem_type|
     it "renders #{stem_type} block processed by KaTeX" do
       given <<~ADOC
         [#{stem_type}]
@@ -51,52 +51,52 @@ describe 'Integration Tests' do
         C = \\alpha + \\beta Y^{\\gamma} + \\epsilon
         ++++
       ADOC
-      should have_tag 'div.stemblock'
-      should have_tag 'math'
-      should_not have_tag '.katex-error'
+      expect(output).to have_tag 'div.stemblock'
+      expect(output).to have_tag 'math'
+      expect(output).not_to have_tag '.katex-error'
     end
 
     it "renders inline #{stem_type}:[] processed by KaTeX" do
       given "Do some math: #{stem_type}:[E = mc^2]"
 
-      should have_tag 'p', text: /^Do some math: /
-      should have_tag 'math'
-      should_not have_tag '.katex-error'
+      expect(output).to have_tag 'p', text: /^Do some math: /
+      expect(output).to have_tag 'math'
+      expect(output).not_to have_tag '.katex-error'
     end
   end
 
 
-  context 'document without stem attribute' do
+  context 'without stem attribute' do
     context 'when config require_stem_attr is true' do
       let(:processor_opts) {{ require_stem_attr: true }}
 
       ['stem', 'latexmath'].each do |stem_type|
-        include_examples :unprocessed, stem_type
+        include_examples 'unprocessed', stem_type
       end
     end
 
     context 'when config require_stem_attr is false' do
       let(:processor_opts) {{ require_stem_attr: false }}
 
-      include_examples :unprocessed, 'stem'
-      include_examples :processed, 'latexmath'
+      include_examples 'unprocessed', 'stem'
+      include_examples 'processed', 'latexmath'
     end
   end
 
-  context 'document with :stem: latexmath' do
+  context 'with :stem: latexmath' do
     let(:attributes) {{ 'stem' => 'latexmath' }}
 
-    include_examples :processed, 'stem'
-    include_examples :processed, 'latexmath'
+    include_examples 'processed', 'stem'
+    include_examples 'processed', 'latexmath'
 
     # Issue #2
     it 'renders inline stem:[] with "<" and ">" processed by KaTeX' do
       given 'Do some math: stem:[a < b > c]'
 
-      should have_tag 'math'
-      should have_tag 'mo', text: '<'
-      should have_tag 'mo', text: '>'
-      should_not have_tag '.katex-error'
+      expect(output).to have_tag 'math'
+      expect(output).to have_tag 'mo', text: '<'
+      expect(output).to have_tag 'mo', text: '>'
+      expect(output).not_to have_tag '.katex-error'
     end
 
     # Issue #3 (affects only JS)
@@ -108,14 +108,16 @@ describe 'Integration Tests' do
         \\beta = 55
         ++++
       ADOC
-      should have_tag 'math'
-      should_not have_tag '.katex-error'
+      expect(output).to have_tag 'math'
+      expect(output).not_to have_tag '.katex-error'
+      expect(output).to have_tag '.katex-html'
     end
 
     it 'renders error when stem content is invalid' do
       given 'Do some math: stem:[foo &]'
 
-      should have_tag '.katex-html', text: /KaTeX parse error/
+      expect(output).to have_tag '.katex-error'
+      expect(output).to have_tag '.katex-error', title: /KaTeX parse error/
     end
 
     context 'when config katex-throw-on-error is true' do


### PR DESCRIPTION
First of all, @jirutka thanks for making this extension available.

This PR bumps ruby version from 2.3 to 3.0 along with the other dependencies fixing issue #7. The objective of this PR is to ensure that `asciidoctor-katex` remains compatible with the latest version of `asciidoc` and all of its dependencies.

I have also corrected all linting issues raised by `rubocop`. 
